### PR TITLE
Separate function to add gamma-hurdle columns to dgp_df

### DIFF
--- a/hetmatpy/pipeline.py
+++ b/hetmatpy/pipeline.py
@@ -9,6 +9,25 @@ import hetmatpy.degree_weight
 import hetmatpy.hetmat
 
 
+def add_gamma_hurdle_to_dgp_df(dgp_df):
+    """
+    Edit a degree-grouped permutation dataframe to include gamma-hurdle
+    distribution parameters.
+    """
+    # Validate dgp_df
+    if not isinstance(dgp_df, pandas.DataFrame):
+        raise ValueError('add_gamma_hurdle_to_dgp_df: dgp_df must be a pandas.DataFrame')
+    missing = {'nnz', 'sum', 'sum_of_squares'} - set(dgp_df.columns)
+    if missing:
+        raise ValueError('add_gamma_hurdle_to_dgp_df: dgp_df missing the following required columns: ' + ', '.join(missing))
+    # Compute gamma-hurdle parameters
+    dgp_df['mean_nz'] = dgp_df['sum'] / dgp_df['nnz']
+    dgp_df['sd_nz'] = ((dgp_df['sum_of_squares'] - dgp_df['sum'] ** 2 / dgp_df['nnz']) / (dgp_df['nnz'] - 1)) ** 0.5
+    dgp_df['beta'] = dgp_df['mean_nz'] / dgp_df['sd_nz'] ** 2
+    dgp_df['alpha'] = dgp_df['mean_nz'] * dgp_df['beta']
+    return dgp_df
+
+
 def combine_dwpc_dgp(graph, metapath, damping, ignore_zeros=False, max_p_value=1.0):
     """
     Combine DWPC information with degree-grouped permutation summary metrics.
@@ -16,10 +35,7 @@ def combine_dwpc_dgp(graph, metapath, damping, ignore_zeros=False, max_p_value=1
     """
     stats_path = graph.get_running_degree_group_path(metapath, 'dwpc', damping, extension='.tsv.gz')
     dgp_df = pandas.read_table(stats_path)
-    dgp_df['mean_nz'] = dgp_df['sum'] / dgp_df['nnz']
-    dgp_df['sd_nz'] = ((dgp_df['sum_of_squares'] - dgp_df['sum'] ** 2 / dgp_df['nnz']) / (dgp_df['nnz'] - 1)) ** 0.5
-    dgp_df['beta'] = dgp_df['mean_nz'] / dgp_df['sd_nz'] ** 2
-    dgp_df['alpha'] = dgp_df['mean_nz'] * dgp_df['beta']
+    dgp_df = add_gamma_hurdle_to_dgp_df(dgp_df)
     degrees_to_dgp = dgp_df.set_index(['source_degree', 'target_degree']).to_dict(orient='index')
     dwpc_row_generator = hetmatpy.degree_group.dwpc_to_degrees(
         graph, metapath, damping=damping, ignore_zeros=ignore_zeros)

--- a/hetmatpy/pipeline.py
+++ b/hetmatpy/pipeline.py
@@ -19,7 +19,11 @@ def add_gamma_hurdle_to_dgp_df(dgp_df):
         raise ValueError('add_gamma_hurdle_to_dgp_df: dgp_df must be a pandas.DataFrame')
     missing = {'nnz', 'sum', 'sum_of_squares'} - set(dgp_df.columns)
     if missing:
-        raise ValueError('add_gamma_hurdle_to_dgp_df: dgp_df missing the following required columns: ' + ', '.join(missing))
+        raise ValueError(
+            'add_gamma_hurdle_to_dgp_df: '
+            'dgp_df missing the following required columns: ' +
+            ', '.join(missing)
+        )
     # Compute gamma-hurdle parameters
     dgp_df['mean_nz'] = dgp_df['sum'] / dgp_df['nnz']
     dgp_df['sd_nz'] = ((dgp_df['sum_of_squares'] - dgp_df['sum'] ** 2 / dgp_df['nnz']) / (dgp_df['nnz'] - 1)) ** 0.5


### PR DESCRIPTION
This makes it possible to compute gamma-hurdle parameters for degree-grouped permutations without combining them with real-network DWPCs.

Will be helpful for https://github.com/greenelab/hetmech-backend/pull/8.