### PR TITLE
Fixed float error in empirical p_value calculation

### DIFF
--- a/hetmatpy/pipeline.py
+++ b/hetmatpy/pipeline.py
@@ -88,7 +88,7 @@ def calculate_empirical_p_value(row):
         return 0.0
     if row['sd_nz'] == 0:
         # The DWPCs in the permuted network are identical
-        if row['dwpc'] <= row['mean_nz']:
+        if row['dwpc'] <= row['mean_nz'] + FLOAT_ERROR_TOLERANCE:
             # The DWPC you found in the true network is smaller than or equal
             # to those in the permuted network
             return row['nnz'] / row['n']

--- a/hetmatpy/tests/test_pipeline.py
+++ b/hetmatpy/tests/test_pipeline.py
@@ -138,8 +138,8 @@ def test_calculate_sd(sum_of_squares, unsquared_sum, number_nonzero, expected_ou
       'nnz': 2086,
       'n_perms': 200,
       'mean_nz': 7.323728709931212,
-      'sd_nz': 0.0,
-      'p_value': 0.0}, 0.02556372549),
+      'sd_nz': 0.0
+      }, 0.02556372549),
 ])
 def test_calculate_p_value(row, expected_output):
     assert calculate_p_value(row) == pytest.approx(expected_output, rel=1e-4)

--- a/hetmatpy/tests/test_pipeline.py
+++ b/hetmatpy/tests/test_pipeline.py
@@ -73,7 +73,7 @@ def test_calculate_sd(sum_of_squares, unsquared_sum, number_nonzero, expected_ou
 
 
 @pytest.mark.parametrize('row, expected_output', [
-    # Zero path count
+    # zero path count
     ({'path_count': 0,
       'sd_nz': 2.0,
       'dwpc': 4.0,
@@ -105,7 +105,7 @@ def test_calculate_sd(sum_of_squares, unsquared_sum, number_nonzero, expected_ou
       'beta': 2.0,
       'sum': 1.0
       }, 0.0),
-    # Normal gamma hurdle case
+    # normal gamma hurdle case
     ({'path_count': 5,
       'sd_nz': 1.0,
       'dwpc': 2.5,
@@ -125,6 +125,21 @@ def test_calculate_sd(sum_of_squares, unsquared_sum, number_nonzero, expected_ou
       'beta': 2.0,
       'sum': 0.0
       }, 0.0),
+    # dwpc slightly larger than mean_nz, but within float error tolerance
+    ({'source_id': 'DB00193',
+      'target_id': 'DOID:0050425',
+      'source_name': 'Tramadol',
+      'target_name': 'restless legs syndrome',
+      'source_degree': 1,
+      'target_degree': 10,
+      'path_count': 1,
+      'dwpc': 7.323728709931218,
+      'n': 81600,
+      'nnz': 2086,
+      'n_perms': 200,
+      'mean_nz': 7.323728709931212,
+      'sd_nz': 0.0,
+      'p_value': 0.0}, 0.02556372549),
 ])
 def test_calculate_p_value(row, expected_output):
     assert calculate_p_value(row) == pytest.approx(expected_output, rel=1e-4)


### PR DESCRIPTION
Found a bug where we were getting zero p_values for metapaths because the dwpc was slightly larger than the 'mean_nz' due to float error. Added the float error tolerance to fix the bug and added a test to make sure it doesn't reoccur.