### PR TITLE
dwpc_to_degrees: ignore_redundant option for symmetric metapaths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     python_requires='>=3.6',
     install_requires=[
-        'hetio>=0.2.9',
+        'hetio>=0.2.10',
         'numpy',
         'pandas',
         'scipy',


### PR DESCRIPTION
degree_group.dwpc_to_degrees option to prevent duplicate DWPCs for inverse orientations of symmetric metapaths.

Refs https://github.com/greenelab/hetmech-backend/issues/43