### PR TITLE
calculate_gamma_hurdle_p_value: calc beta / alpha as needed

### DIFF
--- a/hetmatpy/tests/test_pipeline.py
+++ b/hetmatpy/tests/test_pipeline.py
@@ -74,93 +74,101 @@ def test_calculate_sd(sum_of_squares, unsquared_sum, number_nonzero, expected_ou
 
 @pytest.mark.parametrize('row, expected_output', [
     # zero path count
-    ({'path_count': 0,
-      'sd_nz': 2.0,
-      'dwpc': 4.0,
-      'nnz': 1,
-      'n': 4,
-      'alpha': 1.0,
-      'beta': 2.0,
-      'sum': 1.0
-      }, 1.0),
+    ({
+        'path_count': 0,
+        'sd_nz': 2.0,
+        'dwpc': 4.0,
+        'nnz': 1,
+        'n': 4,
+        'alpha': 1.0,
+        'beta': 2.0,
+        'sum': 1.0,
+    }, 1.0),
     # zero standard deviation with dwpc lower than mean
-    ({'path_count': 5,
-      'sd_nz': 0.0,
-      'dwpc': 2.0,
-      'mean_nz': 3.0,
-      'nnz': 3,
-      'n': 8,
-      'alpha': 1.0,
-      'beta': 2.0,
-      'sum': 1.0
-      }, .375),
+    ({
+        'path_count': 5,
+        'sd_nz': 0.0,
+        'dwpc': 2.0,
+        'mean_nz': 3.0,
+        'nnz': 3,
+        'n': 8,
+        'alpha': 1.0,
+        'beta': 2.0,
+        'sum': 1.0,
+    }, .375),
     # zero standard deviation with dwpc higher than mean
-    ({'path_count': 5,
-      'sd_nz': 0.0,
-      'dwpc': 4.0,
-      'mean_nz': 3.0,
-      'nnz': 1,
-      'n': 4,
-      'alpha': 1.0,
-      'beta': 2.0,
-      'sum': 1.0
-      }, 0.0),
+    ({
+        'path_count': 5,
+        'sd_nz': 0.0,
+        'dwpc': 4.0,
+        'mean_nz': 3.0,
+        'nnz': 1,
+        'n': 4,
+        'alpha': 1.0,
+        'beta': 2.0,
+        'sum': 1.0,
+    }, 0.0),
     # normal gamma hurdle case
-    ({'path_count': 5,
-      'sd_nz': 1.0,
-      'dwpc': 2.5,
-      'nnz': 1,
-      'n': 10,
-      'alpha': 1.0,
-      'beta': 1.0,
-      'sum': 1.0
-      }, .008208),
+    ({
+        'path_count': 5,
+        'sd_nz': 1.0,
+        'dwpc': 2.5,
+        'nnz': 1,
+        'n': 10,
+        'alpha': 1.0,
+        'beta': 1.0,
+        'sum': 1.0,
+    }, .008208),
     # number nonzero is itself zero
-    ({'path_count': 5,
-      'sd_nz': 0.0,
-      'dwpc': 2.0,
-      'nnz': 0,
-      'n': 4,
-      'alpha': 1.0,
-      'beta': 2.0,
-      'sum': 0.0
-      }, 0.0),
+    ({
+        'path_count': 5,
+        'sd_nz': 0.0,
+        'dwpc': 2.0,
+        'nnz': 0,
+        'n': 4,
+        'alpha': 1.0,
+        'beta': 2.0,
+        'sum': 0.0,
+    }, 0.0),
     # dwpc slightly larger than mean_nz, but within float error tolerance
-    ({'source_id': 'DB00193',
-      'target_id': 'DOID:0050425',
-      'source_name': 'Tramadol',
-      'target_name': 'restless legs syndrome',
-      'source_degree': 1,
-      'target_degree': 10,
-      'path_count': 1,
-      'dwpc': 7.323728709931218,
-      'n': 81600,
-      'nnz': 2086,
-      'n_perms': 200,
-      'mean_nz': 7.323728709931212,
-      'sd_nz': 0.0
-      }, 0.02556372549),
+    ({
+        'source_id': 'DB00193',
+        'target_id': 'DOID:0050425',
+        'source_name': 'Tramadol',
+        'target_name': 'restless legs syndrome',
+        'source_degree': 1,
+        'target_degree': 10,
+        'path_count': 1,
+        'dwpc': 7.323728709931218,
+        'n': 81600,
+        'nnz': 2086,
+        'n_perms': 200,
+        'mean_nz': 7.323728709931212,
+        'sd_nz': 0.0,
+    }, 0.02556372549),
     # standard deviation is None
-    ({'path_count': 5,
-      'sd_nz': None,
-      'dwpc': 1.5,
-      'nnz': 10,
-      'n': 100,
-      'alpha': 1.0,
-      'beta': 1.0,
-      'sum': 1.0,
-      'mean_nz': 2
-      }, .1),
+    ({
+        'path_count': 5,
+        'sd_nz': None,
+        'dwpc': 1.5,
+        'nnz': 10,
+        'n': 100,
+        'alpha': 1.0,
+        'beta': 1.0,
+        'sum': 1.0,
+        'mean_nz': 2,
+    }, .1),
 ])
 def test_calculate_p_value(row, expected_output):
     assert calculate_p_value(row) == pytest.approx(expected_output, rel=1e-4)
 
 
 def test_add_gamma_hurdle():
-    df_dict = {'nnz': [1, 3, 3],
-               'sum': [4.0, 4.0, 3.0],
-               'sum_of_squares': [4.0, 6.0, 3.0 + 1e-15],
-               }
+    df_dict = {
+        'nnz': [1, 3, 3],
+        'sum': [4.0, 4.0, 3.0],
+        'sum_of_squares': [4.0, 6.0, 3.0 + 1e-15],
+    }
     dgp_df = pandas.DataFrame(df_dict)
     dgp_df = add_gamma_hurdle_to_dgp_df(dgp_df)
 

--- a/hetmatpy/tests/test_pipeline.py
+++ b/hetmatpy/tests/test_pipeline.py
@@ -228,4 +228,4 @@ def test_calculate_gamma_hurdle_p_value_missing_beta_alpha():
     p_value = calculate_gamma_hurdle_p_value(row)
     assert pytest.approx(p_value) == 0.0048801093094888
     assert pytest.approx(row['beta']) == 3.1160706804802087
-    assert pytest.approx(row['alpha']) == 1 # should fail
+    assert pytest.approx(row['alpha']) == 9.452108483415754

--- a/hetmatpy/tests/test_pipeline.py
+++ b/hetmatpy/tests/test_pipeline.py
@@ -3,10 +3,11 @@ import pandas
 import pytest
 
 from hetmatpy.pipeline import (
-    grouper,
-    calculate_sd,
-    calculate_p_value,
     add_gamma_hurdle_to_dgp_df,
+    calculate_gamma_hurdle_p_value,
+    calculate_p_value,
+    calculate_sd,
+    grouper,
     path_does_not_exist,
 )
 
@@ -210,3 +211,21 @@ def test_add_gamma_hurdle():
 ])
 def test_path_does_not_exist(row, expected_output):
     assert path_does_not_exist(row) == expected_output
+
+
+def test_calculate_gamma_hurdle_p_value_missing_beta_alpha():
+    """
+    Testing data from https://search.het.io/?source=1502&target=41593&metapaths=BPpGbCcSE
+    """
+    row = {
+        'n': 202_969_400,
+        'nnz': 1_447_786,
+        'mean_nz': 3.03334213264993,
+        'sd_nz': 0.986636206544574,
+        'path_count': 3,
+        'dwpc': 2.48807892922932,
+    }
+    p_value = calculate_gamma_hurdle_p_value(row)
+    assert 0.0048801093094888 == pytest.approx(p_value)
+    assert row['beta'] == 1 # should fail
+    assert row['alpha'] == 1 # should fail

--- a/hetmatpy/tests/test_pipeline.py
+++ b/hetmatpy/tests/test_pipeline.py
@@ -226,6 +226,6 @@ def test_calculate_gamma_hurdle_p_value_missing_beta_alpha():
         'dwpc': 2.48807892922932,
     }
     p_value = calculate_gamma_hurdle_p_value(row)
-    assert 0.0048801093094888 == pytest.approx(p_value)
-    assert row['beta'] == 1 # should fail
-    assert row['alpha'] == 1 # should fail
+    assert pytest.approx(p_value) == 0.0048801093094888
+    assert pytest.approx(row['beta']) == 3.1160706804802087
+    assert pytest.approx(row['alpha']) == 1 # should fail


### PR DESCRIPTION
For hetmech-backend, I'd like the ability to calculate a p-value when n, nnz, sd_mean, sd_nz are known, but not beta and alpha. This PR enables `calculate_gamma_hurdle_p_value` to compute beta and alpha when missing from the `row` input dictionary.