### PR TITLE
Fix division error

### DIFF
--- a/hetmatpy/pipeline.py
+++ b/hetmatpy/pipeline.py
@@ -55,7 +55,8 @@ def add_gamma_hurdle_to_dgp_df(dgp_df):
             ', '.join(missing)
         )
     # Compute gamma-hurdle parameters
-    dgp_df['mean_nz'] = dgp_df['sum'] / dgp_df['nnz']
+    with numpy.errstate(divide='ignore'):
+        dgp_df['mean_nz'] = dgp_df['sum'] / dgp_df['nnz']
     dgp_df['sd_nz'] = dgp_df[['sum_of_squares', 'sum', 'nnz']].apply(lambda row: calculate_sd(*row), raw=True, axis=1)
     dgp_df['beta'] = (dgp_df['mean_nz'] / dgp_df['sd_nz'] ** 2).replace(numpy.inf, numpy.nan)
     dgp_df['alpha'] = dgp_df['mean_nz'] * dgp_df['beta']

--- a/hetmatpy/pipeline.py
+++ b/hetmatpy/pipeline.py
@@ -55,10 +55,11 @@ def add_gamma_hurdle_to_dgp_df(dgp_df):
             ', '.join(missing)
         )
     # Compute gamma-hurdle parameters
-    with numpy.errstate(divide='ignore'):
-        dgp_df['mean_nz'] = dgp_df['sum'] / dgp_df['nnz']
+    # to_numeric prevents ZeroDivisionError when nnz is an column with object dtype
+    # https://github.com/pandas-dev/pandas/issues/46292
+    dgp_df['mean_nz'] = dgp_df['sum'] / pandas.to_numeric(dgp_df['nnz'])
     dgp_df['sd_nz'] = dgp_df[['sum_of_squares', 'sum', 'nnz']].apply(lambda row: calculate_sd(*row), raw=True, axis=1)
-    dgp_df['beta'] = (dgp_df['mean_nz'] / dgp_df['sd_nz'] ** 2).replace(numpy.inf, numpy.nan)
+    dgp_df['beta'] = (dgp_df['mean_nz'] / pandas.to_numeric(dgp_df['sd_nz'] ** 2)).replace(numpy.inf, numpy.nan)
     dgp_df['alpha'] = dgp_df['mean_nz'] * dgp_df['beta']
 
     return dgp_df

--- a/hetmatpy/tests/test_diffusion.py
+++ b/hetmatpy/tests/test_diffusion.py
@@ -74,7 +74,7 @@ class TestDualNormalize:
     def get_problem_matrix(type):
         """Return a problematic matrix of specified type"""
         matrix_dict = {
-            'empty_row': numpy.array([[1, 2], [3, 4], []]),
+            'empty_row': numpy.array([[1, 2], [3, 4], []], dtype=object),
             'empty_matrix': numpy.array([[], [], []]),
             'nan_matrix': numpy.array([[numpy.nan, numpy.nan], [1, 0.5]]),
             'infinite_matrix': numpy.array([[numpy.inf, numpy.inf], [1, 0.5]]),

--- a/hetmatpy/tests/test_pipeline.py
+++ b/hetmatpy/tests/test_pipeline.py
@@ -175,10 +175,11 @@ def test_add_gamma_hurdle():
 
     # Test nnz = 1
     expected_mean_nz_0 = 4.0
+    print(dgp_df)
     assert expected_mean_nz_0 == dgp_df['mean_nz'][0]
-    assert numpy.isnan(dgp_df['sd_nz'][0])
-    assert numpy.isnan(dgp_df['beta'][0])
-    assert numpy.isnan(dgp_df['alpha'][0])
+    assert pandas.isna(dgp_df['sd_nz'][0])
+    assert pandas.isna(dgp_df['beta'][0])
+    assert pandas.isna(dgp_df['alpha'][0])
 
     # Test a normal case
     expected_mean_nz_1 = 4 / 3
@@ -195,8 +196,8 @@ def test_add_gamma_hurdle():
     expected_sd_nz_2 = 0.0
     assert expected_mean_nz_2 == dgp_df['mean_nz'][2]
     assert expected_sd_nz_2 == dgp_df['sd_nz'][2]
-    assert numpy.isnan(dgp_df['beta'][2])
-    assert numpy.isnan(dgp_df['alpha'][2])
+    assert pandas.isna(dgp_df['beta'][2])
+    assert pandas.isna(dgp_df['alpha'][2])
 
 
 @pytest.mark.parametrize('row, expected_output', [

--- a/hetmatpy/tests/test_pipeline.py
+++ b/hetmatpy/tests/test_pipeline.py
@@ -1,4 +1,3 @@
-import numpy
 import pandas
 import pytest
 


### PR DESCRIPTION
Got this error on [CI](https://github.com/hetio/hetmatpy/runs/5833262318?check_suite_focus=true#step:5:25):

```python-traceback
____________________________ test_add_gamma_hurdle _____________________________

    def test_add_gamma_hurdle():
        df_dict = {
            'nnz': [1, 3, 3],
            'sum': [4.0, 4.0, 3.0],
            'sum_of_squares': [4.0, 6.0, 3.0 + 1e-15],
        }
        dgp_df = pandas.DataFrame(df_dict)
>       dgp_df = add_gamma_hurdle_to_dgp_df(dgp_df)

hetmatpy/tests/test_pipeline.py:174: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/hetmatpy/pipeline.py:60: in add_gamma_hurdle_to_dgp_df
    dgp_df['beta'] = (dgp_df['mean_nz'] / dgp_df['sd_nz'] ** 2).replace(numpy.inf, numpy.nan)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/pandas/core/ops/common.py:65: in new_method
    return method(self, other)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/pandas/core/ops/__init__.py:343: in wrapper
    result = arithmetic_op(lvalues, rvalues, op)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/pandas/core/ops/array_ops.py:190: in arithmetic_op
    res_values = na_arithmetic_op(lvalues, rvalues, op)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/pandas/core/ops/array_ops.py:143: in na_arithmetic_op
    result = expressions.evaluate(op, left, right)
/opt/hostedtoolcache/Python/3.6.15/x64/lib/python3.6/site-packages/pandas/core/computation/expressions.py:2[33](https://github.com/hetio/hetmatpy/runs/5833262318?check_suite_focus=true#step:5:33): in evaluate
    return _evaluate(op, op_str, a, b)  # type: ignore
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

op = <built-in function truediv>, op_str = '/'
a = array([4.        , 1.33333333, 1.        ])
b = array([nan, 0.33333333333333[34](https://github.com/hetio/hetmatpy/runs/5833262318?check_suite_focus=true#step:5:34), 0.0], dtype=object)

    def _evaluate_standard(op, op_str, a, b):
        """
        Standard evaluation.
        """
        if _TEST_MODE:
            _store_test_result(False)
        with np.errstate(all="ignore"):
>           return op(a, b)
E           ZeroDivisionError: float division by zero
```

Looks like something has changed in how division by zero is being handled. Noting https://github.com/pandas-dev/pandas/issues/46292.